### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ React Native library that implements PayPal [Checkout](https://developers.braint
 
 ## Getting started
 
-`$ npm install react-native-paypal --save` or `$ yarn install react-native-paypal`
+`$ npm install react-native-paypal --save` or `$ yarn add react-native-paypal`
 
 ### Mostly automatic installation
 
@@ -47,6 +47,7 @@ At this point you should be able to build both Android and iOS.
 1. In XCode, in the project navigator, right click `Libraries` ➜ `Add Files to [your project's name]`
 1. Go to `node_modules` ➜ `react-native-paypal` and add `RNPaypal.xcodeproj`
 1. In XCode, in the project navigator, select your project. Add `libRNPaypal.a` to your project's `Build Phases` ➜ `Link Binary With Libraries`
+1. In XCode, in the project navigator, select your project. Add `$(SRCROOT)/../node_modules/react-native-paypal/ios` to your project's `Build Settings` ➜ `Header Search Paths`
 
 #### Android
 

--- a/ios/RNPaypal.xcodeproj/project.pbxproj
+++ b/ios/RNPaypal.xcodeproj/project.pbxproj
@@ -83,7 +83,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastUpgradeCheck = 0830;
-				ORGANIZATIONNAME = Facebook;
+				ORGANIZATIONNAME = Smarkets Limited;
 				TargetAttributes = {
 					58B511DA1A9E6C8500147676 = {
 						CreatedOnToolsVersion = 6.1.1;
@@ -95,6 +95,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = 58B511D21A9E6C8500147676;


### PR DESCRIPTION
Tried to reproduce #11, but on a fresh project and successful `react-native link react-native-paypal` the header search paths are updated correctly. 

So this just updates the missing instruction for manual installation.