### PR TITLE
Fix Currency Code Option Name (Android)

### DIFF
--- a/android/src/main/java/com/smarkets/paypal/RNPaypalModule.java
+++ b/android/src/main/java/com/smarkets/paypal/RNPaypalModule.java
@@ -52,8 +52,8 @@ public class RNPaypalModule extends ReactContextBaseJavaModule implements Activi
     PayPalRequest request = new PayPalRequest(options.getString("amount"))
         .intent(PayPalRequest.INTENT_AUTHORIZE);
 
-    if (options.hasKey("currencyCode"))
-        request.currencyCode(options.getString("currencyCode"));
+    if (options.hasKey("currency"))
+        request.currency(options.getString("currency"));
     if (options.hasKey("localeCode"))
         request.localeCode(options.getString("localeCode"));
     if (options.hasKey("shippingAddressRequired"))


### PR DESCRIPTION
Fix the currency code option name to properly get the currency option value.