### PR TITLE
Add iOS9+ support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ React Native library that implements PayPal [Checkout](https://developers.braint
       [[RNPaypal sharedInstance] configure];
     }
 
+    // if you support only iOS 9+, add the following method
+    - (BOOL)application:(UIApplication *)application openURL:(NSURL *)url
+      options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options
+    {
+      return [[RNPaypal sharedInstance] application:application openURL:url options:options];
+    }
+    
+    // otherwise, if you support iOS 9, add the following method
     - (BOOL)application:(UIApplication *)application openURL:(NSURL *)url
       sourceApplication:(NSString *)sourceApplication annotation:(id)annotation
     {

--- a/ios/RNPaypal.h
+++ b/ios/RNPaypal.h
@@ -14,5 +14,6 @@
 
 - (void)configure;
 - (BOOL)application:(UIApplication *)application openURL:(NSURL *)url sourceApplication:(NSString *)sourceApplication annotation:(id)annotation;
+- (BOOL)application:(UIApplication *)application openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options;
 
 @end

--- a/ios/RNPaypal.m
+++ b/ios/RNPaypal.m
@@ -93,6 +93,16 @@ RCT_EXPORT_METHOD(
     return NO;
 }
 
+- (BOOL)application:(UIApplication *)application
+    openURL:(NSURL *)url
+    options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options
+{
+    if ([url.scheme localizedCaseInsensitiveCompare:URLScheme] == NSOrderedSame) {
+        return [BTAppSwitch handleOpenURL:url options:options];
+    }
+    return NO;
+}
+
 - (void)configure {
     NSString *bundleIdentifier = [[NSBundle mainBundle] bundleIdentifier];
     NSString *urlscheme = [NSString stringWithFormat:@"%@.payments", bundleIdentifier];

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 
 {
   "name": "react-native-paypal",
-  "version": "2.0.4",
+  "version": "2.1.0",
   "description": "React Native library that implements PayPal Checkout flow using purely native code",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This allows apps that only need to support iOS 9+ to use the alternative interface for openURL.