### PR TITLE
Fixed react-native peer dependency warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
     "url": "git@github.com:smarkets/react-native-paypal.git"
   },
   "peerDependencies": {
-    "react-native": "^0.41.2"
+    "react-native": ">=0.41.2"
   }
 }


### PR DESCRIPTION
This will fix this warning that happens when installing react-native paypal
`warning " > react-native-paypal@2.1.0" has incorrect peer dependency "react-native@^0.41.2".`

This library should support any version of react-native higher than 0.41.2