### PR TITLE
Bump braintree dependency from 3.13.0 to 3.14.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -55,6 +55,6 @@ repositories {
 dependencies {
     api 'com.facebook.react:react-native:+'
 
-    compileOnly 'com.braintreepayments.api:braintree:3.13.0'
+    compileOnly 'com.braintreepayments.api:braintree:3.14.0'
 }
   

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -24,7 +24,7 @@ android {
     buildToolsVersion rootProject.hasProperty('buildToolsVersion') ? rootProject.buildToolsVersion : DEFAULT_BUILD_TOOLS_VERSION
 
     defaultConfig {
-        minSdkVersion 21
+        minSdkVersion 19
         targetSdkVersion rootProject.hasProperty('targetSdkVersion') ? rootProject.targetSdkVersion : DEFAULT_TARGET_SDK_VERSION
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
Trying to fix HostnameVerifier warning from Google Play Console.
https://github.com/smarkets/react-native-paypal/issues/52