### PR TITLE
Add requestDeviceData method to collect Braintree device data

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -56,5 +56,5 @@ dependencies {
     api 'com.facebook.react:react-native:+'
 
     compileOnly 'com.braintreepayments.api:braintree:3.14.1'
+    compileOnly 'com.braintreepayments.api:data-collector:3.+'
 }
-  

--- a/android/src/main/java/com/smarkets/paypal/RNPaypalModule.java
+++ b/android/src/main/java/com/smarkets/paypal/RNPaypalModule.java
@@ -6,11 +6,13 @@ import android.content.Intent;
 
 import androidx.fragment.app.FragmentActivity;
 import com.braintreepayments.api.BraintreeFragment;
+import com.braintreepayments.api.DataCollector;
 import com.braintreepayments.api.PayPal;
 import com.braintreepayments.api.exceptions.ErrorWithResponse;
 import com.braintreepayments.api.exceptions.InvalidArgumentException;
 import com.braintreepayments.api.interfaces.BraintreeCancelListener;
 import com.braintreepayments.api.interfaces.BraintreeErrorListener;
+import com.braintreepayments.api.interfaces.BraintreeResponseListener;
 import com.braintreepayments.api.interfaces.PaymentMethodNonceCreatedListener;
 import com.braintreepayments.api.models.PayPalAccountNonce;
 import com.braintreepayments.api.models.PayPalRequest;
@@ -152,6 +154,30 @@ public class RNPaypalModule extends ReactContextBaseJavaModule implements Activi
       request.localeCode(options.getString("localeCode"));
 
     PayPal.requestBillingAgreement(braintreeFragment, request);
+  }
+
+  @ReactMethod
+  public void requestDeviceData(
+          final String token,
+          final Promise promise
+  ) {
+    BraintreeFragment braintreeFragment = null;
+
+    try {
+      braintreeFragment = initializeBraintreeFragment(token, promise);
+    } catch (Exception e) {
+      promise.reject("braintree_sdk_setup_failed", e);
+      return;
+    }
+
+    DataCollector.collectDeviceData(braintreeFragment, new BraintreeResponseListener<String>() {
+      @Override
+      public void onResponse(String deviceData) {
+        WritableMap result = Arguments.createMap();
+        result.putString("deviceData", deviceData);
+        promise.resolve(result);
+      }
+    });
   }
 
   @Override

--- a/index.d.ts
+++ b/index.d.ts
@@ -63,6 +63,10 @@ export interface PaypalResponse {
     phone: string
 }
 
+export interface DeviceDataResponse {
+    deviceData: string
+}
+
 declare function requestOneTimePayment(token: string, {
     amount,
     currency,
@@ -88,3 +92,5 @@ declare function requestBillingAgreement(token: string, {
     currency ? : paypalSupportedCurrencies,
     localeCode ? : paypalLocalCodes,
 }): Promise <PaypalResponse> ;
+
+declare function requestDeviceData(token: string): Promise <DeviceDataResponse> ;

--- a/index.js
+++ b/index.js
@@ -7,4 +7,5 @@ export default RNPaypal;
 export const {
   requestOneTimePayment,
   requestBillingAgreement,
+  requestDeviceData,
 } = RNPaypal;

--- a/ios/RNPaypal.h
+++ b/ios/RNPaypal.h
@@ -7,8 +7,9 @@
 
 #import "BraintreeCore.h"
 #import "BraintreePayPal.h"
+#import "BTDataCollector.h"
 
-@interface RNPaypal : UIViewController <RCTBridgeModule, BTAppSwitchDelegate, BTViewControllerPresentingDelegate>
+@interface RNPaypal : UIViewController <RCTBridgeModule, BTAppSwitchDelegate, BTViewControllerPresentingDelegate, BTDataCollectorDelegate>
 
 + (instancetype)sharedInstance;
 

--- a/paypalExample/App.tsx
+++ b/paypalExample/App.tsx
@@ -11,6 +11,7 @@ import {
 import {
   requestOneTimePayment,
   requestBillingAgreement,
+  requestDeviceData,
   PaypalResponse,
 } from 'react-native-paypal';
 
@@ -26,6 +27,7 @@ const App = () => {
     lastName: '',
     phone: '',
   });
+  const [deviceData, setDeviceData] = useState('');
   const [amount, setAmount] = useState('10');
   const [
     billingAgreementDescription,
@@ -41,6 +43,12 @@ const App = () => {
     requestBillingAgreement(token, {billingAgreementDescription})
       .then(setSuccess)
       .catch((err) => setError(err.message));
+
+  const requestData = () =>
+    requestDeviceData(token)
+        .then((({ deviceData }) => setDeviceData(deviceData)))
+        .catch((err) => setError(err.message));
+
 
   return (
     <SafeAreaView>
@@ -76,6 +84,10 @@ const App = () => {
             <Text style={styles.buttonText}>Request Billing</Text>
           </TouchableOpacity>
 
+          <TouchableOpacity onPress={requestData} style={styles.button}>
+            <Text style={styles.buttonText}>Request Device Data</Text>
+          </TouchableOpacity>
+
           {!!error && <Text style={styles.errorText}>Error: {error}</Text>}
 
           <Text style={styles.sectionTitle}>Response:</Text>
@@ -85,6 +97,7 @@ const App = () => {
           <Text>First Name: {success.firstName}</Text>
           <Text>Last Name: {success.lastName}</Text>
           <Text>Phone: {success.phone}</Text>
+          <Text>deviceData: {deviceData}</Text>
         </View>
       </ScrollView>
     </SafeAreaView>

--- a/paypalExample/android/app/build.gradle
+++ b/paypalExample/android/app/build.gradle
@@ -187,6 +187,7 @@ dependencies {
 
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.0.0"
     implementation "com.braintreepayments.api:braintree:3.14.1"
+    implementation "com.braintreepayments.api:data-collector:3.+"
 
     debugImplementation("com.facebook.flipper:flipper:${FLIPPER_VERSION}") {
       exclude group:'com.facebook.fbjni'

--- a/paypalExample/ios/Podfile
+++ b/paypalExample/ios/Podfile
@@ -33,4 +33,5 @@ target 'paypalExample-tvOS' do
 end
 
 pod 'Braintree', '~> 4.35.0'
+pod 'Braintree/DataCollector'
 pod 'RNPaypal', :path => '../node_modules/react-native-paypal'

--- a/paypalExample/ios/Podfile.lock
+++ b/paypalExample/ios/Podfile.lock
@@ -8,6 +8,8 @@ PODS:
   - Braintree/Card (4.35.0):
     - Braintree/Core
   - Braintree/Core (4.35.0)
+  - Braintree/DataCollector (4.35.0):
+    - Braintree/Core
   - Braintree/PayPal (4.35.0):
     - Braintree/Core
     - Braintree/PayPalOneTouch
@@ -318,7 +320,7 @@ PODS:
     - React-Core (= 0.63.2)
     - React-cxxreact (= 0.63.2)
     - React-jsi (= 0.63.2)
-  - RNPaypal (2.2.0):
+  - RNPaypal (3.1.1):
     - Braintree
     - React
   - Yoga (1.14.0)
@@ -327,6 +329,7 @@ PODS:
 
 DEPENDENCIES:
   - Braintree (~> 4.35.0)
+  - Braintree/DataCollector
   - DoubleConversion (from `../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)
   - FBLazyVector (from `../node_modules/react-native/Libraries/FBLazyVector`)
   - FBReactNativeSpec (from `../node_modules/react-native/Libraries/FBReactNativeSpec`)
@@ -486,10 +489,10 @@ SPEC CHECKSUMS:
   React-RCTText: 1b6773e776e4b33f90468c20fe3b16ca3e224bb8
   React-RCTVibration: 4d2e726957f4087449739b595f107c0d4b6c2d2d
   ReactCommon: a0a1edbebcac5e91338371b72ffc66aa822792ce
-  RNPaypal: 71327bc2b1d1af8ec6578a9b8069a9bfa201fd98
+  RNPaypal: ac01980ea29ad4df3b46f99ea58fa290914d734f
   Yoga: 7740b94929bbacbddda59bf115b5317e9a161598
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
-PODFILE CHECKSUM: 71591b0aba0212054b86dee5ba491669792cb307
+PODFILE CHECKSUM: 2959c167c0f09e859a1b23b8e604ff6057b91754
 
-COCOAPODS: 1.9.1
+COCOAPODS: 1.10.0


### PR DESCRIPTION
Hello everyone,

I added a new method called `requestDeviceData` to collect [device data](https://developers.braintreepayments.com/guides/advanced-fraud-management-tools/device-data-collection/) from Braintree.

I'd like to get your opinions through this draft PR.
