### PR TITLE
Add `offerPayLater` option to `requestOneTimePayment`

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,9 @@ const {
     shippingAddressRequired: false,
     userAction: 'commit', // display 'Pay Now' on the PayPal review page
     // one of 'authorize', 'sale', 'order'. defaults to 'authorize'. see details here: https://developer.paypal.com/docs/api/payments/v1/#payment-create-request-body
-    intent: 'authorize', 
+    intent: 'authorize',
+    // support pay later offers. see details here: https://developer.paypal.com/braintree/docs/guides/paypal/pay-later-offers/android/v3
+    offerPayLater: false, 
   }
 );
 

--- a/android/src/main/java/com/smarkets/paypal/RNPaypalModule.java
+++ b/android/src/main/java/com/smarkets/paypal/RNPaypalModule.java
@@ -58,6 +58,8 @@ public class RNPaypalModule extends ReactContextBaseJavaModule implements Activi
     PayPalRequest request = new PayPalRequest(options.getString("amount"))
         .intent(PayPalRequest.INTENT_AUTHORIZE);
 
+    if (options.hasKey("offerPayLater"))
+        request.offerPayLater(options.getBoolean("offerPayLater"));
     if (options.hasKey("currency"))
         request.currencyCode(options.getString("currency"));
     if (options.hasKey("displayName"))

--- a/index.d.ts
+++ b/index.d.ts
@@ -92,6 +92,7 @@ declare function requestOneTimePayment(token: string, {
     shippingAddressRequired,
     userAction,
     intent,
+    offerPayLater,
 }: {
     amount: string,
     currency ? : paypalSupportedCurrencies,
@@ -99,6 +100,7 @@ declare function requestOneTimePayment(token: string, {
     shippingAddressRequired ? : boolean,
     userAction ? : 'commit' | 'continue',
     intent ? : 'sale' | 'authorize' | 'order',
+    offerPayLater ? : boolean,
 }): Promise <PaypalResponse> ;
 
 declare function requestBillingAgreement(token: string, {

--- a/ios/RNPaypal.m
+++ b/ios/RNPaypal.m
@@ -42,6 +42,8 @@ RCT_EXPORT_METHOD(
         payPalDriver.appSwitchDelegate = self;
 
         BTPayPalRequest *request= [[BTPayPalRequest alloc] initWithAmount:options[@"amount"]];
+        BOOL offerPayLater = [options[@"offerPayLater"] boolValue];
+        if (offerPayLater) request.offerPayLater = offerPayLater;
         NSString* currency = options[@"currency"];
         if (currency) request.currencyCode = currency;
         NSString* displayName = options[@"displayName"];


### PR DESCRIPTION
Adds an `offerPayLater` option to `requestOneTimePayment` for supporting [pay later offers](https://developer.paypal.com/braintree/docs/guides/paypal/pay-later-offers/android/v3).

Tested on iOS and Android.
